### PR TITLE
fix(payload): Use correct url to parse host

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/GitHubRepositoryTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/GitHubRepositoryTrigger.java
@@ -159,7 +159,7 @@ public class GitHubRepositoryTrigger extends Trigger<Job<?, ?>> implements GitHu
                     GitHubRepositoryCheckResult repoResult = new GitHubRepositoryCheckResult();
 
                     repoResult.setAction(repoPayload.getAction());
-                    repoResult.setHost(repoPayload.getRepository().getUrl().getHost());
+                    repoResult.setHost(repoPayload.getRepository().getHtmlUrl().getHost());
                     repoResult.setOrganization(repoPayload.getOrganization().getLogin());
                     repoResult.setRepository(repoPayload.getRepository().getName());
 


### PR DESCRIPTION
Correct property from where take host. Because structure mapped 1:1 to GH Event payload, `url` is api url, where `http_url` is what we need and contain `github.com` host.